### PR TITLE
Refactoring package.json. Source maps must be used only for unit tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3892,4 +3892,3 @@ var powerbi;
         })(utils = extensibility.utils || (extensibility.utils = {}));
     })(extensibility = powerbi.extensibility || (powerbi.extensibility = {}));
 })(powerbi || (powerbi = {}));
-//# sourceMappingURL=index.js.map

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "powerbi-visuals-utils-dataviewutils": "^0.3.0",
     "powerbi-visuals-utils-testutils": "^0.2.0",
     "tslint": "3.15.1",
-    "typescript": "1.8.10",
+    "typescript": "2.1.4",
     "typings": "2.0.0",
     "coveralls": "2.11.15",
     "karma-coverage": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:map": "tsc --sourceMap",
     "postbuild": "npm run lessc",
     "test": "karma start",
-    "pretest": "npm run build",
+    "pretest": "npm run build:map",
     "lint": "tslint \"+(src|test)/**/*.ts\"",
     "typings": "typings",
     "typings:install": "typings install",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
         "experimentalDecorators": true,
         "target": "ES5",
         "declaration": true,
-        "outFile": "./lib/index.js",
-        "sourceMap": true
+        "outFile": "./lib/index.js"
     },
     "files": [
         "typings/index.d.ts",


### PR DESCRIPTION
Task - 16169