### PR TITLE
Remove width restriction of title in legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+* Remove width restriction of title in legend
+* Added new option to drawDefaultLabelsForDataPointChart function to control behavior of collided labels
+
 ## 1.3.0
 * Updated packages
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-chartutils",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "ChartUtils",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-chartutils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ChartUtils",
   "main": "lib/index.js",
   "repository": {

--- a/src/dataLabel/dataLabelManager.ts
+++ b/src/dataLabel/dataLabelManager.ts
@@ -67,7 +67,7 @@ module powerbi.extensibility.utils.chart.dataLabel {
         }
 
         /** Arranges the lables position and visibility*/
-        public hideCollidedLabels(viewport: IViewport, data: any[], layout: any, addTransform: boolean = false): LabelEnabledDataPoint[] {
+        public hideCollidedLabels(viewport: IViewport, data: any[], layout: any, addTransform: boolean = false, hideCollidedLabels: boolean = true): LabelEnabledDataPoint[] {
 
             // Split size into a grid
             let arrangeGrid = new DataLabelArrangeGrid(viewport, data, layout);
@@ -96,7 +96,7 @@ module powerbi.extensibility.utils.chart.dataLabel {
 
                 let position: IRect = this.calculateContentPosition(info, info.contentPosition, data[i].size, info.anchorMargin);
 
-                if (DataLabelManager.isValid(position) && !this.hasCollisions(arrangeGrid, info, position, viewport)) {
+                if (DataLabelManager.isValid(position) && (!this.hasCollisions(arrangeGrid, info, position, viewport) || !hideCollidedLabels)) {
                     data[i].labelX = position.left - transform.x;
                     data[i].labelY = position.top - transform.y;
 

--- a/src/dataLabel/dataLabelUtils.ts
+++ b/src/dataLabel/dataLabelUtils.ts
@@ -181,13 +181,13 @@ module powerbi.extensibility.utils.chart.dataLabel.utils {
     }
 
     export function drawDefaultLabelsForDataPointChart(data: any[], context: d3.Selection<any>, layout: ILabelLayout,
-        viewport: IViewport, isAnimator: boolean = false, animationDuration?: number, hasSelection?: boolean): d3.selection.Update<any> {
+        viewport: IViewport, isAnimator: boolean = false, animationDuration?: number, hasSelection?: boolean, hideCollidedLabels: boolean = true): d3.selection.Update<any> {
 
         // Hide and reposition labels that overlap
-        let dataLabelManager = new DataLabelManager(),
-            filteredData = dataLabelManager.hideCollidedLabels(viewport, data, layout),
-            hasAnimation = isAnimator && !!animationDuration,
-            labels = selectLabels(filteredData, context, false, hasAnimation);
+        let dataLabelManager = new DataLabelManager();
+        let filteredData = dataLabelManager.hideCollidedLabels(viewport, data, layout, false, hideCollidedLabels);
+        let hasAnimation: boolean = isAnimator && !!animationDuration;
+        let labels: d3.selection.Update<any> = selectLabels(filteredData, context, false, hasAnimation);
 
         if (!labels) {
             return;

--- a/src/legend/svgLegend.ts
+++ b/src/legend/svgLegend.ts
@@ -107,14 +107,12 @@ module powerbi.extensibility.utils.chart.legend {
         private static LegendIconRadius = 5;
         private static LegendIconRadiusFactor = 5;
         private static MaxTextLength = 60;
-        private static MaxTitleLength = 80;
         private static TextAndIconPadding = 5;
         private static TitlePadding = 15;
         private static LegendEdgeMariginWidth = 10;
         private static LegendMaxWidthFactor = 0.3;
         private static TopLegendHeight = 24;
         private static DefaultTextMargin = PixelConverter.fromPointToPixel(SVGLegend.DefaultFontSizeInPt);
-        private static DefaultMaxLegendFactor = SVGLegend.MaxTitleLength / SVGLegend.DefaultTextMargin;
         private static LegendIconYRatio = 0.52;
 
         // Navigation Arrow constants
@@ -420,32 +418,9 @@ module powerbi.extensibility.utils.chart.legend {
                 let isHorizontal = this.isTopOrBottom(this.orientation),
                     maxMeasureLength: number;
 
-                if (isHorizontal) {
-                    let fontSizeMargin = this.legendFontSizeMarginValue > SVGLegend.DefaultTextMargin
-                        ? SVGLegend.TextAndIconPadding + this.legendFontSizeMarginDifference
-                        : SVGLegend.TextAndIconPadding;
-
-                    let fixedHorizontalIconShift = SVGLegend.TextAndIconPadding + SVGLegend.LegendIconRadius;
-                    let fixedHorizontalTextShift = SVGLegend.LegendIconRadius + fontSizeMargin + fixedHorizontalIconShift;
-                    // TODO This can be negative for narrow viewports. May need to rework this logic.
-                    maxMeasureLength = this.parentViewport.width * SVGLegend.LegendMaxWidthFactor - fixedHorizontalTextShift - SVGLegend.LegendEdgeMariginWidth;
-                }
-                else {
-                    maxMeasureLength = this.legendFontSizeMarginValue < SVGLegend.DefaultTextMargin ? SVGLegend.MaxTitleLength :
-                        SVGLegend.MaxTitleLength + (SVGLegend.DefaultMaxLegendFactor * this.legendFontSizeMarginDifference);
-                }
-
                 let textProperties = SVGLegend.getTextProperties(true, title, this.data.fontSize);
                 let text = title;
                 width = textMeasurementService.measureSvgTextWidth(textProperties);
-
-                if (width > maxMeasureLength) {
-                    text = textMeasurementService.getTailoredTextOrDefault(textProperties, maxMeasureLength);
-                    textProperties.text = text;
-
-                    // Remeasure the text since its measurement may be different than the max (ex. when the max is negative, the text will be ellipsis, and not have a negative width)
-                    width = textMeasurementService.measureSvgTextWidth(textProperties);
-                };
 
                 if (isHorizontal) {
                     width += SVGLegend.TitlePadding;

--- a/test/legendTest.ts
+++ b/test/legendTest.ts
@@ -480,7 +480,7 @@ module powerbi.extensibility.utils.chart.legend.test {
             });
 
             it("Intelligent Layout: Long label must be cut off", () => {
-                let legendData = [{
+                let legendData: LegendDataPoint[] = [{
                     label: "Really long label, but i haven't the space to show",
                     color: "red",
                     icon: LegendIcon.Line,

--- a/test/legendTest.ts
+++ b/test/legendTest.ts
@@ -476,6 +476,26 @@ module powerbi.extensibility.utils.chart.legend.test {
 
                 expect($(".legendItem").length).toBe(1);
                 expect($($(".legendText")[0]).text()).not.toContain("…");
+                expect($($(".legendText")[0]).text()).not.toContain("...");
+            });
+
+            it("Intelligent Layout: Long label must be cut off", () => {
+                let legendData = [{
+                    label: "Really long label, but i haven't the space to show",
+                    color: "red",
+                    icon: LegendIcon.Line,
+                    identity: createSelectionIdentity(1),
+                    selected: false
+                }];
+
+                legend.changeOrientation(LegendPosition.Left);
+                legend.drawLegend({ dataPoints: legendData }, { height: 100, width: 200 });
+
+                flushAllD3Transitions();
+
+                expect($(".legendItem").length).toBe(1);
+                expect($($(".legendText")[0]).text()).toContain("...");
+                expect($($(".legendText")[0]).text().length).toBeGreaterThan(3);
             });
 
             it("Intelligent Layout: Lots of small labels should get compacted in horizontal layout", () => {


### PR DESCRIPTION
The size of legends title restricted by the MaxTitleLength variable.
But also the size of title restricted by the width of legends panel. 
See this line:
https://github.com/zBritva/powerbi-visuals-utils-chartutils/blob/fix_title_label_width/src/legend/svgLegend.ts#L428

Usually MaxTitleLength smallest than the width of legends panel. It will cut text in the title of legend panel despite enough place for full text.

Added new option to drawDefaultLabelsForDataPointChart to control behavior of collided labels