### PR TITLE
Add legend service in usage guide

### DIFF
--- a/docs/usage/usage-guide.md
+++ b/docs/usage/usage-guide.md
@@ -6,3 +6,4 @@ This package contains the following classes, interfaces and methods:
 * [Axis Helper](../api/axis-helper.md) - provide all necessary methods to maintain chart axes
 * [DataLabelManager](../api/data-label-manager.md) - helps to create and maintain labels
 * [DataLabelUtils](../api/data-label-utils.md) - label manager utils
+* [Legend Service](../api/legend.md) - provides helper interfaces for creating and managing legends


### PR DESCRIPTION
This adds the missing link to the legend service. 