### PR TITLE
Change legendGroup id to class

### DIFF
--- a/src/legend/svgLegend.ts
+++ b/src/legend/svgLegend.ts
@@ -169,7 +169,7 @@ export class SVGLegend implements ILegend {
 
         this.group = this.svg
             .append("g")
-            .attr("id", "legendGroup");
+            .classed("legendGroup", true);
 
         this.interactiveBehavior = interactiveBehavior ? interactiveBehavior : new LegendBehavior();
         this.interactivityService = interactivityService;

--- a/test/legendTest.ts
+++ b/test/legendTest.ts
@@ -322,7 +322,7 @@ describe("legend", () => {
                 let behavior = new MockOpacityBehavior();
                 const svg = select(element.querySelector("div#jasmine-fixtures svg"));
                 const clearCatcher = appendClearCatcher(svg);
-                const itemsSelection = svg.select("#legendGroup").selectAll(".legendItem");
+                const itemsSelection = svg.select(".legendGroup").selectAll(".legendItem");
 
                 let behaviorOptions: LegendBehaviorOptions = {
                     legendItems: itemsSelection,


### PR DESCRIPTION
legendGroup id is changed to class to avoid non-unique ids notification. The test for legend is changed, too.