### PR TITLE
Added new legend positions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 
-name: Release Build
+name: release
 
 on:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+## 8.3.0
+
+### Module `legend`
+* Added `LegendPosition.TopRight` and `LegendPosition.BottomRight` — horizontal legend with items right-aligned to the chart area; falls back to left-aligned with a navigation arrow on overflow.
+* Added matching `legendPosition` string constants `topRight` and `bottomRight`.
+* Exported orientation helpers: `isLeft`, `isRight`, `isTop`, `isBottom`, `isTopOrBottom`, `isCentered`, `isRightAligned`. `isTop`/`isBottom` now also match the new right-aligned variants.
+* Fixed clipping of vertical centered legends (`LeftCenter`/`RightCenter`) when items overflowed (missing `Math.max(0, ...)` clamp).
+
 ## 8.2.2
 
 * Updated packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1287,7 +1286,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1335,7 +1333,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1830,7 +1827,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2993,7 +2989,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6941,7 +6936,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7044,7 +7038,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7240,7 +7233,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7484,7 +7476,6 @@
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -7552,7 +7543,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-utils-chartutils",
-  "version": "8.2.2",
+  "version": "8.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-utils-chartutils",
-      "version": "8.2.2",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.4",
@@ -903,6 +903,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1286,6 +1287,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1333,6 +1335,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1827,6 +1830,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2989,6 +2993,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6936,6 +6941,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7038,6 +7044,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7233,6 +7240,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7476,6 +7484,7 @@
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -7543,6 +7552,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-chartutils",
-  "version": "8.2.2",
+  "version": "8.3.0",
   "description": "ChartUtils",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/legend/legend.ts
+++ b/src/legend/legend.ts
@@ -46,10 +46,58 @@ export function isLeft(orientation: LegendPosition): boolean {
     }
 }
 
+export function isRight(orientation: LegendPosition): boolean {
+    switch (orientation) {
+        case LegendPosition.Right:
+        case LegendPosition.RightCenter:
+            return true;
+        default:
+            return false;
+    }
+}
+
 export function isTop(orientation: LegendPosition): boolean {
     switch (orientation) {
         case LegendPosition.Top:
         case LegendPosition.TopCenter:
+        case LegendPosition.TopRight:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isBottom(orientation: LegendPosition): boolean {
+    switch (orientation) {
+        case LegendPosition.Bottom:
+        case LegendPosition.BottomCenter:
+        case LegendPosition.BottomRight:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isTopOrBottom(orientation: LegendPosition): boolean {
+    return isTop(orientation) || isBottom(orientation);
+}
+
+export function isCentered(orientation: LegendPosition): boolean {
+    switch (orientation) {
+        case LegendPosition.TopCenter:
+        case LegendPosition.BottomCenter:
+        case LegendPosition.LeftCenter:
+        case LegendPosition.RightCenter:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isRightAligned(orientation: LegendPosition): boolean {
+    switch (orientation) {
+        case LegendPosition.TopRight:
+        case LegendPosition.BottomRight:
             return true;
         default:
             return false;

--- a/src/legend/legendInterfaces.ts
+++ b/src/legend/legendInterfaces.ts
@@ -39,7 +39,19 @@ export enum LegendPosition {
     BottomCenter,
     RightCenter,
     LeftCenter,
+    /**
+     * Horizontal legend above the chart, items right-aligned to the chart area.
+     * On overflow falls back to left-aligned layout with a navigation arrow
+     * (when the legend is scrollable), instead of keeping right alignment with
+     * horizontal clipping/scroll. This mirrors the native Power BI legend behavior.
+     */
     TopRight,
+    /**
+     * Horizontal legend below the chart, items right-aligned to the chart area.
+     * On overflow falls back to left-aligned layout with a navigation arrow
+     * (when the legend is scrollable), instead of keeping right alignment with
+     * horizontal clipping/scroll. This mirrors the native Power BI legend behavior.
+     */
     BottomRight,
 }
 

--- a/src/legend/legendInterfaces.ts
+++ b/src/legend/legendInterfaces.ts
@@ -39,6 +39,8 @@ export enum LegendPosition {
     BottomCenter,
     RightCenter,
     LeftCenter,
+    TopRight,
+    BottomRight,
 }
 
 export interface ISelectableDataPoint{

--- a/src/legend/legendPosition.ts
+++ b/src/legend/legendPosition.ts
@@ -32,3 +32,5 @@ export const topCenter: string = "TopCenter";
 export const bottomCenter: string = "BottomCenter";
 export const leftCenter: string = "LeftCenter";
 export const rightCenter: string = "RightCenter";
+export const topRight: string = "TopRight";
+export const bottomRight: string = "BottomRight";

--- a/src/legend/svgLegend.ts
+++ b/src/legend/svgLegend.ts
@@ -39,6 +39,7 @@ import {
 } from "powerbi-visuals-utils-svgutils";
 
 import { ILegend, LegendData, LegendDataPoint, LegendPosition } from "./legendInterfaces";
+import { isBottom, isRight, isTopOrBottom, isCentered, isRightAligned } from "./legend";
 
 import * as Markers from "./markers";
 
@@ -168,14 +169,11 @@ export class SVGLegend implements ILegend {
             "width", legendViewport.width || (orientation === LegendPosition.None ? 0 : this.parentViewport.width)
         );
 
-        const isRight = orientation === LegendPosition.Right || orientation === LegendPosition.RightCenter,
-            isBottom = orientation === LegendPosition.Bottom || orientation === LegendPosition.BottomCenter;
-
         this.svg.style(
-            "margin-left", isRight ? (this.parentViewport.width - legendViewport.width) + "px" : null
+            "margin-left", isRight(orientation) ? (this.parentViewport.width - legendViewport.width) + "px" : null
         );
         this.svg.style(
-            "margin-top", isBottom ? (this.parentViewport.height - legendViewport.height) + "px" : null,
+            "margin-top", isBottom(orientation) ? (this.parentViewport.height - legendViewport.height) + "px" : null,
         );
     }
 
@@ -185,6 +183,8 @@ export class SVGLegend implements ILegend {
             case LegendPosition.Bottom:
             case LegendPosition.TopCenter:
             case LegendPosition.BottomCenter:
+            case LegendPosition.TopRight:
+            case LegendPosition.BottomRight:
                 const pixelHeight = PixelConverter.fromPointToPixel(this.data && this.data.fontSize
                     ? this.data.fontSize
                     : SVGLegend.DefaultFontSizeInPt);
@@ -259,7 +259,7 @@ export class SVGLegend implements ILegend {
 
         // Adding back the workaround for Legend Left/Right position for Map
         const mapControls = this.element.getElementsByClassName("mapControl");
-        if (mapControls.length > 0 && !this.isTopOrBottom(this.orientation)) {
+        if (mapControls.length > 0 && !isTopOrBottom(this.orientation)) {
             for (let i = 0; i < mapControls.length; ++i) {
                 const element = <HTMLElement>mapControls[i];
                 element.style.display = "inline-block";
@@ -274,17 +274,21 @@ export class SVGLegend implements ILegend {
 
         const group = this.group;
 
-        // transform the wrapping group if position is centered
-        if (this.isCentered(this.orientation)) {
+        // transform the wrapping group if position is centered or right-aligned
+        if (isCentered(this.orientation)) {
             let centerOffset = 0;
-            if (this.isTopOrBottom(this.orientation)) {
+            if (isTopOrBottom(this.orientation)) {
                 centerOffset = Math.max(0, (this.parentViewport.width - this.visibleLegendWidth) / 2);
                 group.attr("transform", svgManipulation.translate(centerOffset, 0));
             }
             else {
-                centerOffset = Math.max((this.parentViewport.height - this.visibleLegendHeight) / 2);
+                centerOffset = Math.max(0, (this.parentViewport.height - this.visibleLegendHeight) / 2);
                 group.attr("transform", svgManipulation.translate(0, centerOffset));
             }
+        }
+        else if (isRightAligned(this.orientation)) {
+            const rightOffset = Math.max(0, this.parentViewport.width - this.visibleLegendWidth);
+            group.attr("transform", svgManipulation.translate(rightOffset, 0));
         }
         else {
             group.attr("transform", null);
@@ -444,7 +448,7 @@ export class SVGLegend implements ILegend {
         const hasTitle = !!title;
 
         if (hasTitle) {
-            const isHorizontal = this.isTopOrBottom(this.orientation);
+            const isHorizontal = isTopOrBottom(this.orientation);
 
             const textProperties = SVGLegend.getTextProperties(title, this.data.fontSize, this.data.fontFamily);
             let text = title;
@@ -498,7 +502,7 @@ export class SVGLegend implements ILegend {
         let navArrows: NavigationArrow[];
         let numberOfItems: number;
 
-        if (this.isTopOrBottom(this.orientation)) {
+        if (isTopOrBottom(this.orientation)) {
             navArrows = this.isScrollable ? this.calculateHorizontalNavigationArrowsLayout(title) : [];
             numberOfItems = this.calculateHorizontalLayout(dataPoints, title, navArrows);
         }
@@ -786,6 +790,20 @@ export class SVGLegend implements ILegend {
         }
 
         this.visibleLegendWidth = occupiedWidth;
+
+        // When the legend is right-aligned (TopRight/BottomRight):
+        //  - If everything fits, the group is translated to the right edge in
+        //    drawLegendInternal and items render right-aligned with no arrow.
+        //  - If items overflow, native visuals fall back to left-aligned rendering
+        //    with the "next" arrow at the right edge of the viewport — matching the
+        //    standard Top/Bottom overflow behavior. We achieve that here by setting
+        //    visibleLegendWidth to the full parent width so the translation in
+        //    drawLegendInternal becomes 0; the arrow keeps its default x set by
+        //    updateNavigationArrowLayout (parentViewport.width - LegendArrowWidth).
+        if (isRightAligned(this.orientation) && numberOfItems !== dataPointsLength) {
+            this.visibleLegendWidth = this.parentViewport.width;
+        }
+
         this.updateNavigationArrowLayout(navigationArrows, dataPointsLength, numberOfItems);
 
         return numberOfItems;
@@ -953,30 +971,6 @@ export class SVGLegend implements ILegend {
 
         path.attr("d", (d: NavigationArrow) => d.path)
             .attr("transform", (d: NavigationArrow) => d.rotateTransform);
-    }
-
-    private isTopOrBottom(orientation: LegendPosition): boolean {
-        switch (orientation) {
-            case LegendPosition.Top:
-            case LegendPosition.Bottom:
-            case LegendPosition.BottomCenter:
-            case LegendPosition.TopCenter:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    private isCentered(orientation: LegendPosition): boolean {
-        switch (orientation) {
-            case LegendPosition.BottomCenter:
-            case LegendPosition.LeftCenter:
-            case LegendPosition.RightCenter:
-            case LegendPosition.TopCenter:
-                return true;
-            default:
-                return false;
-        }
     }
 
     public reset(): void { }

--- a/src/legend/svgLegend.ts
+++ b/src/legend/svgLegend.ts
@@ -793,13 +793,16 @@ export class SVGLegend implements ILegend {
 
         // When the legend is right-aligned (TopRight/BottomRight):
         //  - If everything fits, the group is translated to the right edge in
-        //    drawLegendInternal and items render right-aligned with no arrow.
-        //  - If items overflow, native visuals fall back to left-aligned rendering
-        //    with the "next" arrow at the right edge of the viewport — matching the
-        //    standard Top/Bottom overflow behavior. We achieve that here by setting
-        //    visibleLegendWidth to the full parent width so the translation in
-        //    drawLegendInternal becomes 0; the arrow keeps its default x set by
-        //    updateNavigationArrowLayout (parentViewport.width - LegendArrowWidth).
+        //    drawLegendInternal and items render right-aligned.
+        //  - If items overflow, we unconditionally fall back to left-aligned
+        //    rendering by setting visibleLegendWidth to the full parent width so
+        //    the translation in drawLegendInternal becomes 0. This matches the
+        //    standard Top/Bottom overflow layout.
+        //    When scrolling is enabled (isScrollable), updateNavigationArrowLayout
+        //    will additionally place the "next" arrow at the right edge of the
+        //    viewport (parentViewport.width - LegendArrowWidth); when scrolling
+        //    is disabled, navigationArrows is empty and no arrow is rendered, but
+        //    the left-aligned fallback still applies.
         if (isRightAligned(this.orientation) && numberOfItems !== dataPointsLength) {
             this.visibleLegendWidth = this.parentViewport.width;
         }

--- a/test/legendTest.ts
+++ b/test/legendTest.ts
@@ -715,6 +715,127 @@ describe("legend", () => {
             expect(iconY + iconHeight / 2).toBeLessThan((labelY * 2 + labelHeight) * 0.6);
         });
 
+        describe("Centered vertical legend overflow (regression for Math.max(0, ...) clamp)", () => {
+            function parseTranslateY(transform: string | null): number {
+                if (!transform) {
+                    return 0;
+                }
+                const match = /translate\(\s*[-+0-9.eE]+\s*[, ]\s*([-+0-9.eE]+)/.exec(transform);
+                return match ? parseFloat(match[1]) : 0;
+            }
+
+            function expectGroupNotClipped(position: LegendPosition): void {
+                const legendData = getLotsOfLegendData();
+
+                legend.changeOrientation(position);
+                // Force overflow: tall list of items in a short vertical area.
+                legend.drawLegend({ dataPoints: legendData }, { height: 50, width: 200 });
+
+                flushAllD3Transitions();
+
+                const group = element.querySelector("#legendGroup");
+                expect(group).not.toBeNull();
+
+                const translateY = parseTranslateY(group.getAttribute("transform"));
+                // Before the fix this value went negative (group shifted above the
+                // SVG, clipping the title and "previous" arrow).
+                expect(translateY).toBeGreaterThanOrEqual(0);
+            }
+
+            it("LeftCenter with overflowing items does not translate group above 0", () => {
+                expectGroupNotClipped(LegendPosition.LeftCenter);
+            });
+
+            it("RightCenter with overflowing items does not translate group above 0", () => {
+                expectGroupNotClipped(LegendPosition.RightCenter);
+            });
+        });
+
+        describe("Right-aligned horizontal legend (TopRight / BottomRight)", () => {
+            function parseTranslate(transform: string | null): { x: number; y: number } {
+                if (!transform) {
+                    return { x: 0, y: 0 };
+                }
+                const match = /translate\(\s*([-+0-9.eE]+)\s*[, ]\s*([-+0-9.eE]+)?/.exec(transform);
+                if (!match) {
+                    return { x: 0, y: 0 };
+                }
+                return { x: parseFloat(match[1]), y: match[2] ? parseFloat(match[2]) : 0 };
+            }
+
+            function fittingDataPoints(): LegendDataPoint[] {
+                return [
+                    { label: "A", color: "#ff0000", identity: createSelectionIdentity("a"), selected: false },
+                    { label: "B", color: "#00ff00", identity: createSelectionIdentity("b"), selected: false },
+                ];
+            }
+
+            it("TopRight: when items fit, the legend group is translated to the right edge and no nav arrow is rendered", () => {
+                legend.changeOrientation(LegendPosition.TopRight);
+                legend.drawLegend({ dataPoints: fittingDataPoints() }, { height: 100, width: 1000 });
+
+                flushAllD3Transitions();
+
+                const group = element.querySelector("#legendGroup");
+                expect(group).not.toBeNull();
+
+                const translate = parseTranslate(group.getAttribute("transform"));
+                // Items fit, so the group should be shifted right by a positive amount.
+                expect(translate.x).toBeGreaterThan(0);
+                expect(translate.y).toBe(0);
+
+                // No overflow -> no navigation arrows.
+                expect(element.querySelectorAll(".navArrow").length).toBe(0);
+            });
+
+            it("BottomRight: when items fit, the legend group is translated to the right edge", () => {
+                legend.changeOrientation(LegendPosition.BottomRight);
+                legend.drawLegend({ dataPoints: fittingDataPoints() }, { height: 100, width: 1000 });
+
+                flushAllD3Transitions();
+
+                const group = element.querySelector("#legendGroup");
+                const translate = parseTranslate(group.getAttribute("transform"));
+                expect(translate.x).toBeGreaterThan(0);
+                expect(element.querySelectorAll(".navArrow").length).toBe(0);
+            });
+
+            it("TopRight: when items overflow, falls back to left-aligned with a navigation arrow", () => {
+                const legendData = getLotsOfLegendData();
+
+                legend.changeOrientation(LegendPosition.TopRight);
+                // Narrow viewport forces overflow.
+                legend.drawLegend({ dataPoints: legendData }, { height: 100, width: 200 });
+
+                flushAllD3Transitions();
+
+                const group = element.querySelector("#legendGroup");
+                const translate = parseTranslate(group.getAttribute("transform"));
+
+                // Fallback: group is not translated to the right edge anymore.
+                expect(translate.x).toBe(0);
+
+                // The "next" navigation arrow should be visible at the right side.
+                const arrows = element.querySelectorAll(".navArrow");
+                expect(arrows.length).toBeGreaterThan(0);
+            });
+
+            it("BottomRight: when items overflow, falls back to left-aligned with a navigation arrow", () => {
+                const legendData = getLotsOfLegendData();
+
+                legend.changeOrientation(LegendPosition.BottomRight);
+                legend.drawLegend({ dataPoints: legendData }, { height: 100, width: 200 });
+
+                flushAllD3Transitions();
+
+                const group = element.querySelector("#legendGroup");
+                const translate = parseTranslate(group.getAttribute("transform"));
+
+                expect(translate.x).toBe(0);
+                expect(element.querySelectorAll(".navArrow").length).toBeGreaterThan(0);
+            });
+        });
+
         function validateLegendDOM(expectedData: LegendDataPoint[]): void {
             let len = expectedData.length;
             let labels = element.querySelectorAll(".legendText");


### PR DESCRIPTION
### Module `legend`
* Added `LegendPosition.TopRight` and `LegendPosition.BottomRight` — horizontal legend with items right-aligned to the chart area; falls back to left-aligned with a navigation arrow on overflow.
* Added matching `legendPosition` string constants `topRight` and `bottomRight`.
* Exported orientation helpers: `isLeft`, `isRight`, `isTop`, `isBottom`, `isTopOrBottom`, `isCentered`, `isRightAligned`. `isTop`/`isBottom` now also match the new right-aligned variants.
* Fixed clipping of vertical centered legends (`LeftCenter`/`RightCenter`) when items overflowed (missing `Math.max(0, ...)` clamp).

